### PR TITLE
adding graceful exit on SIGINT

### DIFF
--- a/lib/simple_kafka_consumer/consumer.rb
+++ b/lib/simple_kafka_consumer/consumer.rb
@@ -1,6 +1,7 @@
 module SimpleKafkaConsumer
   class Consumer    
-    class_attribute :group_name, :topic_name
+    class_attribute :group_name, :topic_name, :terminated, :timeout
+
     attr_reader :consumer, :logger
     def initialize(kafka_servers, zookeeper_servers, options = {})
       @logger = options.delete(:logger)
@@ -11,15 +12,22 @@ module SimpleKafkaConsumer
         topic_name,
         options
       )
+      Signal.trap("INT") do
+        self.class.terminated = true
+        self.class.timeout = 5
+      end
     end
 
     def run
       debug "partitions: #{consumer.partitions}"
       debug "claimed: #{consumer.claimed}"
       consumer.fetch_loop do |partition, bulk|
-        bulk.each do |message|
-          consume(parse(message))
+        Timeout::timeout(timeout) do
+          bulk.each do |message|
+            consume(parse(message))
+          end
         end
+        break if terminated
       end
     rescue ZK::Exceptions::OperationTimeOut => e
       log e.message


### PR DESCRIPTION
on SIGTERM, we 
1. try to break out of the fetch loop
2. set a timeout of 5 seconds and then raise a `Timeout` exception